### PR TITLE
Updated REDIS_READY_PATTERN to match more Redis versions

### DIFF
--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class RedisServer extends AbstractRedisInstance {
-    private static final String REDIS_READY_PATTERN = ".*The server is now ready to accept connections on port.*";
+    private static final String REDIS_READY_PATTERN = ".*(R|r)eady to accept connections.*";
     private static final int DEFAULT_REDIS_PORT = 6379;
 
     public RedisServer() throws IOException {


### PR DESCRIPTION
Updated REDIS_READY_PATTERN to match more versions of Redis. Since version 4.0.* the final startup statement has changed, embedded Redis loops forever when it does not match the expected pattern. Proposed regex modification matches versions included with embedded-redis and versions 3.0.* and 4.0.*