### PR TITLE
Issue-51: Prints Process Logs in RuntimeException Message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-sudo: false # faster builds
+dist: trusty
 
 jdk:
   - oraclejdk8
@@ -10,7 +10,6 @@ install:
 
 before_script:
   - pip install --user codecov
-  - curl http://www.jpm4j.org/install/script | sh
 
 script:
   - mvn -U -B -V test --fail-at-end -Dsource.skip=true -Dmaven.javadoc.skip=true


### PR DESCRIPTION
This resolves the issue: https://github.com/kstyrc/embedded-redis/issues/51

While resolving logs at the process level is preferred as specified in the pull-request: https://github.com/kstyrc/embedded-redis/pull/113 - this fix takes a much more conservative approach and prints the redis process logs only in case of an error/exception when the server startup pattern is not found. That way we do not need to worry about logs in case of successful redis server starts.

Removed `@override` as they are not needed when implementing interfaces.

Before this fix:
```
java.lang.RuntimeException: Can't start redis server. Check logs for details.
	at redis.embedded.AbstractRedisInstance.awaitRedisServerReady(AbstractRedisInstance.java:67)
	at redis.embedded.AbstractRedisInstance.start(AbstractRedisInstance.java:29)
	at redis.embedded.RedisServer.start(RedisServer.java:9)
```

After this fix error log:
```
java.lang.RuntimeException: Can't start redis server. Check logs for details. Redis process log: 
[63038] 12 Mar 14:16:06.220 # Creating Server TCP listening socket 127.0.0.1:6379: bind: Address already in use
	at redis.embedded.AbstractRedisInstance.awaitRedisServerReady(AbstractRedisInstance.java:60)
	at redis.embedded.AbstractRedisInstance.start(AbstractRedisInstance.java:36)
	at redis.embedded.RedisServer.start(RedisServer.java:9)
```

Without the above fix, the workaround the devs need to write is not perfect like below. The exception message `e.getMessage()` can't be checked for exact cause. We can only guess at it:
```
//    Keep for embedded Redis config testing
    public static void main(String... args) throws Exception {
        int port = 6379;
        RedisServer redisServer = null;
        try{
            redisServer = new RedisServer(port);
            redisServer.start();
        } catch(RuntimeException e) {
            if (e.getMessage().contains("Can't start redis server")) {
                int freePort = SocketUtils.findAvailableTcpPort();
                LOGGER.warn("{} Port already in use. Changing port to {}", port, freePort);
                redisServer = new RedisServer(freePort);
                redisServer.start();
            }
        }
    }
```