### PR TITLE
Adds shutdown hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,19 @@
             <version>2.5</version>
         </dependency>
 
-        <!-- TEST DEPENDENCIES -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
-            <scope>test</scope>
         </dependency>
+
+        <!-- TEST DEPENDENCIES -->
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
@@ -161,6 +167,14 @@
                 <configuration>
                     <pushChanges>false</pushChanges>
                     <tag>${project.version}</tag>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Hi, I had problems running redis-embedded with spring boot in a jenkins pipeline.

Sometimes the redis stop is not efficient leaving the port stuck in the pipeline as a result of which the next job fails.

I added a hook for when the process that started the redis-embedded stops then it forces the redis to stop.

I was unable to create an automated test for this, if anyone has any suggestions I would appreciate it.

when run together with spring it stops the redis in the sequence that spring-context stops.