### PR TITLE
Redirect server output

### DIFF
--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -147,7 +147,7 @@ abstract class AbstractRedisInstance implements Redis {
                 	outputStream.println(line);
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                /* reader has been closed. The connected Redis instance has possibly shut down. */
             }
         }
     }

--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -16,7 +16,9 @@ abstract class AbstractRedisInstance implements Redis {
 	private Process redisProcess;
     private final int port;
 
-    private ExecutorService executor;
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+	private PrintStream err = System.out;
+	private PrintStream out = null;
 
     protected AbstractRedisInstance(int port) {
         this.port = port;
@@ -42,14 +44,26 @@ abstract class AbstractRedisInstance implements Redis {
 
     private void logErrors() {
         final InputStream errorStream = redisProcess.getErrorStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream));
-        Runnable printReaderTask = new PrintReaderRunnable(reader);
-        executor = Executors.newSingleThreadExecutor();
-        executor.submit(printReaderTask);
+        copyStreamInBackground(errorStream, err);
     }
 
+	private void copyStreamInBackground(final InputStream copyFrom, PrintStream copyTo) {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(copyFrom));
+        Runnable printReaderTask = new PrintReaderRunnable(reader, copyTo);
+        executor.submit(printReaderTask);
+	}
+
+	public void outTo(PrintStream out) {
+		this.out = out;
+	}
+
+	public void errTo(PrintStream err) {
+		this.err = err;
+	}
+    
     private void awaitRedisServerReady() throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(redisProcess.getInputStream()));
+    	InputStream stdoutStream = redisProcess.getInputStream();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stdoutStream));
         try {
             StringBuffer outputStringBuffer = new StringBuffer();
             String outputLine;
@@ -62,10 +76,18 @@ abstract class AbstractRedisInstance implements Redis {
                 else{
                     outputStringBuffer.append("\n");
                     outputStringBuffer.append(outputLine);
+                    if(out != null) {
+                    	out.println(outputLine);
+                    }
                 }
             } while (!outputLine.matches(redisReadyPattern()));
         } finally {
-            IOUtils.closeQuietly(reader);
+        	if(out != null) {
+        		/* Continue reading of STDOUT in a background thread. */
+        		copyStreamInBackground(stdoutStream, out);
+        	} else {
+        		IOUtils.closeQuietly(reader);
+        	}
         }
     }
 
@@ -103,9 +125,11 @@ abstract class AbstractRedisInstance implements Redis {
 
     private static class PrintReaderRunnable implements Runnable {
         private final BufferedReader reader;
+		private final PrintStream outputStream;
 
-        private PrintReaderRunnable(BufferedReader reader) {
+        private PrintReaderRunnable(BufferedReader reader, PrintStream outputStream) {
             this.reader = reader;
+            this.outputStream = outputStream;
         }
 
         public void run() {
@@ -120,7 +144,7 @@ abstract class AbstractRedisInstance implements Redis {
             try {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    System.out.println(line);
+                	outputStream.println(line);
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -17,8 +17,8 @@ abstract class AbstractRedisInstance implements Redis {
     private final int port;
 
     private ExecutorService executor = Executors.newSingleThreadExecutor();
-	private PrintStream err = System.out;
-	private PrintStream out = null;
+    private PrintStream out = null; //Ignore Redis output.
+    private PrintStream err = System.err; //Forward Redis error messages to STDERR.
 
     protected AbstractRedisInstance(int port) {
         this.port = port;

--- a/src/main/java/redis/embedded/RedisServerBuilder.java
+++ b/src/main/java/redis/embedded/RedisServerBuilder.java
@@ -22,8 +22,8 @@ public class RedisServerBuilder {
     private int port = 6379;
     private InetSocketAddress slaveOf;
     private String redisConf;
-    private PrintStream out;
-    private PrintStream err;
+    private PrintStream out = null; //Ignore Redis output.
+    private PrintStream err = System.err; //Forward Redis error messages to STDERR.
 
     private StringBuilder redisConfigBuilder;
 

--- a/src/main/java/redis/embedded/RedisServerBuilder.java
+++ b/src/main/java/redis/embedded/RedisServerBuilder.java
@@ -6,6 +6,7 @@ import redis.embedded.exceptions.RedisBuildingException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -21,6 +22,8 @@ public class RedisServerBuilder {
     private int port = 6379;
     private InetSocketAddress slaveOf;
     private String redisConf;
+    private PrintStream out;
+    private PrintStream err;
 
     private StringBuilder redisConfigBuilder;
 
@@ -71,11 +74,36 @@ public class RedisServerBuilder {
         return this;
     }
 
+    /**
+     * Redirect Redis server messages sent to STDOUT.
+     * Usage example: @code{builder.outTo(System.out);}
+     * @param out	Stream to receive Redis output. 
+     * @return {@code this}
+     */
+    public RedisServerBuilder outTo(PrintStream out) {
+    	this.out = out;
+    	return this;
+    }
+
+    /**
+     * Redirect Redis server messages sent to STDERR.
+     * @param err	Stream to receive Redis output. 
+     * Usage example: @code{builder.errTo(System.err);}
+     * @return {@code itself}
+     */
+    public RedisServerBuilder errTo(PrintStream err) {
+    	this.err = err;
+    	return this;
+    }
+
     public RedisServer build() {
         setting("bind "+bind);
         tryResolveConfAndExec();
         List<String> args = buildCommandArgs();
-        return new RedisServer(args, port);
+        RedisServer server = new RedisServer(args, port);
+        server.outTo(out);
+        server.errTo(err);
+        return server;
     }
 
     public void reset() {


### PR DESCRIPTION
Added options to redirect output from the started Redis instances.
Usage: 

	RedisServerBuilder serverBuilder = RedisServer.builder()//
			.outTo(System.out)//
			.errTo(System.err)//
			.redisExecProvider(REDIS_EXEC_PROVIDER);

	RedisSentinelBuilder sentinelBuilder = new RedisSentinelBuilder()//
			.outTo(System.out)//
			.errTo(System.err)//
			.redisExecProvider(REDIS_EXEC_PROVIDER);

	// creates a cluster with 3 sentinels, quorum size of 2 and 3 replication
	// groups, each with one master and one slave
	cluster = RedisCluster.builder()//
			.withServerBuilder(serverBuilder)//
			.withSentinelBuilder(sentinelBuilder)//
			.ephemeral().sentinelCount(3).quorumSize(2).replicationGroup("master1", 1)
			.replicationGroup("master2", 1).replicationGroup("master3", 1).build();
	cluster.start();
