### PR TITLE
Remove slf4j-simple from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>


### PR DESCRIPTION
`slf4j-simple` is logging implementation and it shouldn't be forced as library's transient, non-optional dependency.
Adding `slf4j-simple` was quite disruptive, as it basically breaks applications that include this library but use other slf4j implementations (like logback).
From what I can see, it should be enough to have `commons-logging` in dependencies, and `slf4j-simple` can be used for test dependencies.