### PR TITLE
Security - Upgrade to commons-io 2.8.0 to resolve CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.8.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Embedded Redis is currently using version 2.5 of commons-io. This has the following vulnerability (CVSS score 5.3) - https://nvd.nist.gov/vuln/detail/CVE-2021-29425

Upgrading to 2.7 or higher resolves this.