### PR TITLE
Set slf4j-simple scope as test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.21</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The logging implementation should not be included in dependencies.